### PR TITLE
Jitpack Testing

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -2,6 +2,11 @@
 before_install:
   - sdk install java 8.0.302-open
   - sdk use java 8.0.302-open
+  # Create .m2 folder to use to store jdk 8 path
+  - mkdir -p ~/.m2
+  # We have to store the path because the sdk environment
+  # cannot be accessed in subshells.
+  - sdk home java 8.0.302-open > ~/.m2/jdk_8_path
   - sh ./jitpack/jitpack_build.sh
 install:
   - mvn clean install -pl maptowny-api

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -2,5 +2,6 @@
 before_install:
   - sdk install java 8.0.302-open
   - sdk use java 8.0.302-open
+  - sh ./jitpack/jitpack_build.sh
 install:
-  - sh ./jitpack/jitpack_build.sh && mvn clean install -pl maptowny-api
+  - mvn clean install -pl maptowny-api

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,12 +1,35 @@
-# Keep it simple and only build the API on Jitpack.
+#
+# Copyright (c) 2022 Silverwolfg11
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
+# Keep it relatively simple and only build the API on Jitpack.
 before_install:
   - sdk install java 8.0.302-open
   - sdk use java 8.0.302-open
   # Create .m2 folder to use to store jdk 8 path
   - mkdir -p ~/.m2
-  # We have to store the path because the sdk environment
+  # We have to store the path because SDKMAN
   # cannot be accessed in subshells.
   - sdk home java 8.0.302-open > ~/.m2/jdk_8_path
   - sh ./jitpack/jitpack_build.sh
 install:
+  # Only compile the maptowny-api module
   - mvn clean install -pl maptowny-api

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,7 +1,6 @@
 # Keep it simple and only build the API on Jitpack.
 before_install:
-  - sdk install java 8.0.181-oracle
-  - sdk use java 8.0.181-oracle
+  - sdk install java 8.0.302-open
+  - sdk use java 8.0.302-open
 install:
-  - sh ./jitpack/jitpack_build.sh
-  - mvn clean install -pl maptowny-api
+  - sh ./jitpack/jitpack_build.sh && mvn clean install -pl maptowny-api

--- a/jitpack/jitpack_build.sh
+++ b/jitpack/jitpack_build.sh
@@ -25,7 +25,7 @@ HOME_PATH="$(readlink -f ~)"
 # Create M2 home path
 M2_HOME="$HOME_PATH/.m2"
 # Get path of JDK 8
-JDK_8_HOME="$(sdk home java 8.0.181-oracle)"
+JDK_8_HOME="$(sdk home java 8.0.302-open)"
 # Copy toolchain file to m2 directory
 cp ./jitpack/jitpack_toolchain.xml "$M2_HOME/toolchains.xml"
 # Replace JDK 8 prefix with actual jdk8 home

--- a/jitpack/jitpack_build.sh
+++ b/jitpack/jitpack_build.sh
@@ -22,11 +22,10 @@
 
 # Get absolute path of home directory
 HOME_PATH="$(readlink -f ~)"
-# Create M2 home path
 M2_HOME="$HOME_PATH/.m2"
+
 # Create .m2 folder if it doesn't exist
 mkdir -p "$M2_HOME"
-
 JDK_8_HOME="$(cat "$M2_HOME/jdk_8_path")"
 # Copy toolchain file to m2 directory
 cp ./jitpack/jitpack_toolchain.xml "$M2_HOME/toolchains.xml"

--- a/jitpack/jitpack_build.sh
+++ b/jitpack/jitpack_build.sh
@@ -24,11 +24,10 @@
 HOME_PATH="$(readlink -f ~)"
 # Create M2 home path
 M2_HOME="$HOME_PATH/.m2"
-# Get path of JDK 8
-JDK_8_HOME="$(sdk home java 8.0.302-open)"
-
 # Create .m2 folder if it doesn't exist
 mkdir -p "$M2_HOME"
+
+JDK_8_HOME="$(cat "$M2_HOME/jdk_8_path")"
 # Copy toolchain file to m2 directory
 cp ./jitpack/jitpack_toolchain.xml "$M2_HOME/toolchains.xml"
 # Replace JDK 8 prefix with actual jdk8 home

--- a/jitpack/jitpack_build.sh
+++ b/jitpack/jitpack_build.sh
@@ -26,6 +26,9 @@ HOME_PATH="$(readlink -f ~)"
 M2_HOME="$HOME_PATH/.m2"
 # Get path of JDK 8
 JDK_8_HOME="$(sdk home java 8.0.302-open)"
+
+# Create .m2 folder if it doesn't exist
+mkdir -p "$M2_HOME"
 # Copy toolchain file to m2 directory
 cp ./jitpack/jitpack_toolchain.xml "$M2_HOME/toolchains.xml"
 # Replace JDK 8 prefix with actual jdk8 home


### PR DESCRIPTION
Get jitpack integration working. 

The jitpack build only compiles the API module which is fine since the other modules should not be developed against.

The main reason for getting Jitpack up and working is for it's free javadoc hosting. 