### PR TITLE
Add MapPlatformObservers API

### DIFF
--- a/maptowny-api/src/main/java/me/silverwolfg11/maptowny/platform/MapPlatform.java
+++ b/maptowny-api/src/main/java/me/silverwolfg11/maptowny/platform/MapPlatform.java
@@ -51,6 +51,7 @@ public interface MapPlatform {
      * </ul>
      *
      * @param callback Callback to execute
+     * @deprecated 3.0.0+ - Use {@link MapPlatformObserver} instead.
      */
     default void onFirstInitialize(Runnable callback) {
         callback.run();
@@ -67,10 +68,28 @@ public interface MapPlatform {
      * </ul>
      *
      * @param callback Callback to execute.
+     * @deprecated 3.0.0+ - Use {@link MapPlatformObserver} instead.
      */
     default void onInitialize(Runnable callback) {
         callback.run();
     }
+
+    /**
+     * Register an observer to listen to platform events.
+     * Registering an already registered observer has no effect
+     * and will report as a registration failure.
+     *
+     * @return if registration was successful.
+     * @since 3.0.0
+     */
+    boolean registerObserver(@NotNull MapPlatformObserver observer);
+
+    /**
+     * Unregister an observer.
+     * @return if unregistering was successful.
+     * @since 3.0.0
+     */
+    boolean unregisterObserver(@NotNull MapPlatformObserver observer);
 
     /**
      * Check if the map plugin renders the specific world.
@@ -134,6 +153,8 @@ public interface MapPlatform {
      * Indicate to the platform that it should switch to shutdown mode.
      *
      * The platform will still be able to process all operations during this period.
+     * @deprecated 3.0.0 - Platform cleanup does not need to be split into two phases.
+     * 
      */
     default void startShutdown() {
     }

--- a/maptowny-api/src/main/java/me/silverwolfg11/maptowny/platform/MapPlatformObserver.java
+++ b/maptowny-api/src/main/java/me/silverwolfg11/maptowny/platform/MapPlatformObserver.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2024 Silverwolfg11
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package me.silverwolfg11.maptowny.platform;
+
+/**
+ * Provides an observer interface for map-platform events.
+ * These functions may be called on any thread.
+ * <br><b>Note: Platforms may not implement all events.</b>
+ *
+ * @since 3.0.0
+ */
+public interface MapPlatformObserver {
+    /**
+     * Run initial logic for the observer.
+     * <br>
+     * Called immediately if the map-platform is already enabled
+     * or delayed until the map-platform is enabled for the first time.
+     * Only runs once after the observer is registered (not re-run on platform re-enable).
+     */
+    default void onObserverSetup() {}
+
+    /**
+     * Called when the map-platform is enabling.
+     * <br><br>
+     * If the map-platform is already enabled when the observer is registered, then this is not called.
+     * If {@link #onObserverSetup()} has not been called when the platform is enabling,
+     * then {@link #onObserverSetup()} will be called and this will not.
+     * <br><br>
+     * At this stage, some platforms may not have started marker processing
+     * and may not have process queues, so to be safe avoid
+     * performing platform processing logic in this event.
+     */
+    default void onPlatformEnabled() {}
+
+    /**
+     * Called when the map-platform is disabling.
+     * <br>
+     * At this stage, some platforms may have already stopped marker processing,
+     * so to be safe, avoid performing platform processing logic in this event.
+     */
+    default void onPlatformDisabled() {}
+}

--- a/maptowny-bluemap/src/main/java/me/silverwolfg11/maptowny/platform/bluemap/BlueMapObserverHandler.java
+++ b/maptowny-bluemap/src/main/java/me/silverwolfg11/maptowny/platform/bluemap/BlueMapObserverHandler.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2024 Silverwolfg11
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package me.silverwolfg11.maptowny.platform.bluemap;
+
+import de.bluecolored.bluemap.api.BlueMapAPI;
+import me.silverwolfg11.maptowny.platform.MapPlatformObserver;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.function.Consumer;
+
+public class BlueMapObserverHandler {
+    private final CopyOnWriteArrayList<MapPlatformObserver> observers = new CopyOnWriteArrayList<>();
+    private final List<MapPlatformObserver> unsetupObservers = new ArrayList<>();
+
+    private final Consumer<BlueMapAPI> enableConsumer;
+    private final Consumer<BlueMapAPI> disableConsumer;
+
+    public BlueMapObserverHandler() {
+        enableConsumer = (BlueMapAPI) -> this.onBlueMapEnabled();
+        disableConsumer = (BlueMapAPI) -> this.onBlueMapDisabled();
+
+        BlueMapAPI.onEnable(enableConsumer);
+        BlueMapAPI.onDisable(disableConsumer);
+    }
+
+    public boolean registerObserver(MapPlatformObserver observer) {
+        if (observers.contains(observer)) {
+            return false;
+        }
+
+        synchronized (unsetupObservers) {
+            if (unsetupObservers.contains(observer)) {
+                return false;
+            }
+        }
+
+        setupObserver(observer);
+        return true;
+    }
+
+    public boolean unregisterObserver(MapPlatformObserver observer) {
+        if (observers.remove(observer)) {
+            return true;
+        }
+
+        synchronized (unsetupObservers) {
+            if (unsetupObservers.remove(observer)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public void disableObservers() {
+        BlueMapAPI.unregisterListener(enableConsumer);
+        BlueMapAPI.unregisterListener(disableConsumer);
+    }
+
+    private void setupObserver(MapPlatformObserver observer) {
+        if (BlueMapAPI.getInstance().isPresent()) {
+            observer.onObserverSetup();
+            observers.add(observer);
+        }
+        else {
+            synchronized (unsetupObservers) {
+                unsetupObservers.add(observer);
+            }
+        }
+    }
+
+    private void onBlueMapEnabled() {
+        for (MapPlatformObserver observer : observers) {
+            observer.onPlatformEnabled();
+        }
+
+        List<MapPlatformObserver> tmpObservers;
+        synchronized (unsetupObservers) {
+            tmpObservers = new ArrayList<>(unsetupObservers);
+            unsetupObservers.clear();
+        }
+
+        // Setup first-time observers
+        for (MapPlatformObserver observer : tmpObservers) {
+            observer.onObserverSetup();
+        }
+
+        observers.addAll(tmpObservers);
+    }
+
+    private void onBlueMapDisabled() {
+        for (MapPlatformObserver observer : observers) {
+            observer.onPlatformDisabled();
+        }
+    }
+}

--- a/maptowny-dynmap/src/main/java/me/silverwolfg11/maptowny/platform/dynmap/DynmapObserverHandler.java
+++ b/maptowny-dynmap/src/main/java/me/silverwolfg11/maptowny/platform/dynmap/DynmapObserverHandler.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2024 Silverwolfg11
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package me.silverwolfg11.maptowny.platform.dynmap;
+
+import me.silverwolfg11.maptowny.platform.MapPlatformObserver;
+import org.dynmap.DynmapCommonAPI;
+import org.dynmap.DynmapCommonAPIListener;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicReference;
+
+public class DynmapObserverHandler {
+    private final CopyOnWriteArrayList<MapPlatformObserver> observers = new CopyOnWriteArrayList<>();
+    private final List<MapPlatformObserver> unsetupObservers = new ArrayList<>();
+
+    private final DynmapCommonAPIListener dynmapListener;
+    private final AtomicReference<DynmapCommonAPI> dynmapApiRef = new AtomicReference<>();
+
+    public DynmapObserverHandler() {
+        dynmapListener = new DynmapCommonAPIListener() {
+            @Override
+            public void apiEnabled(DynmapCommonAPI dynmapCommonAPI) {
+                DynmapObserverHandler.this.onDynmapEnabled(dynmapCommonAPI);
+            }
+
+            @Override
+            public void apiDisabled(DynmapCommonAPI api) {
+                DynmapObserverHandler.this.onDynmapDisabled();
+            }
+        };
+
+        // Listener runs immediately if dynmap api is enabled.
+        DynmapCommonAPIListener.register(dynmapListener);
+    }
+
+    public boolean registerObserver(MapPlatformObserver observer) {
+        if (observers.contains(observer)) {
+            return false;
+        }
+
+        synchronized (unsetupObservers) {
+            if (unsetupObservers.contains(observer)) {
+                return false;
+            }
+        }
+
+        setupObserver(observer);
+        return true;
+    }
+
+    public boolean unregisterObserver(MapPlatformObserver observer) {
+        if (observers.remove(observer)) {
+            return true;
+        }
+
+        synchronized (unsetupObservers) {
+            if (unsetupObservers.remove(observer)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public void disableObservers() {
+        DynmapCommonAPIListener.unregister(dynmapListener);
+    }
+
+    private void setupObserver(MapPlatformObserver observer) {
+        if (dynmapApiRef.get() != null) {
+            observer.onObserverSetup();
+            observers.add(observer);
+        }
+        else {
+            synchronized (unsetupObservers) {
+                unsetupObservers.add(observer);
+            }
+        }
+    }
+
+    private void onDynmapEnabled(DynmapCommonAPI api) {
+        dynmapApiRef.set(api);
+
+        for (MapPlatformObserver observer : observers) {
+            observer.onPlatformEnabled();
+        }
+
+        List<MapPlatformObserver> tmpObservers;
+        synchronized (unsetupObservers) {
+            tmpObservers = new ArrayList<>(unsetupObservers);
+            unsetupObservers.clear();
+        }
+
+        // Setup first-time observers
+        for (MapPlatformObserver observer : tmpObservers) {
+            observer.onObserverSetup();
+        }
+
+        observers.addAll(tmpObservers);
+    }
+
+    private void onDynmapDisabled() {
+        dynmapApiRef.set(null);
+
+        for (MapPlatformObserver observer : observers) {
+            observer.onPlatformDisabled();
+        }
+    }
+}

--- a/maptowny-dynmap/src/main/java/me/silverwolfg11/maptowny/platform/dynmap/DynmapPlatform.java
+++ b/maptowny-dynmap/src/main/java/me/silverwolfg11/maptowny/platform/dynmap/DynmapPlatform.java
@@ -23,11 +23,11 @@
 package me.silverwolfg11.maptowny.platform.dynmap;
 
 import me.silverwolfg11.maptowny.platform.MapPlatform;
+import me.silverwolfg11.maptowny.platform.MapPlatformObserver;
 import me.silverwolfg11.maptowny.platform.MapWorld;
 import org.bukkit.Bukkit;
 import org.bukkit.World;
 import org.bukkit.plugin.Plugin;
-import org.bukkit.plugin.java.JavaPlugin;
 import org.dynmap.DynmapAPI;
 import org.dynmap.markers.MarkerIcon;
 import org.jetbrains.annotations.NotNull;
@@ -41,15 +41,26 @@ import java.io.IOException;
 
 public class DynmapPlatform implements MapPlatform {
     private final DynmapAPI dynmapAPI;
+    private final DynmapObserverHandler observerHandler;
 
     public DynmapPlatform() {
         dynmapAPI = (DynmapAPI) Bukkit.getPluginManager().getPlugin("dynmap");
+        observerHandler = new DynmapObserverHandler();
     }
-
 
     @Override
     public @NotNull String getPlatformName() {
         return "dynmap";
+    }
+
+    @Override
+    public boolean registerObserver(@NotNull MapPlatformObserver observer) {
+        return observerHandler.registerObserver(observer);
+    }
+
+    @Override
+    public boolean unregisterObserver(@NotNull MapPlatformObserver observer) {
+        return observerHandler.unregisterObserver(observer);
     }
 
     @Override
@@ -106,6 +117,11 @@ public class DynmapPlatform implements MapPlatform {
         }
 
         return false;
+    }
+
+    @Override
+    public void shutdown() {
+        observerHandler.disableObservers();
     }
 
     // Logger Accessibility

--- a/maptowny-pl3xmap/src/main/java/me/silverwolfg11/maptowny/platform/pl3xmap/Pl3xMapObserverHandler.java
+++ b/maptowny-pl3xmap/src/main/java/me/silverwolfg11/maptowny/platform/pl3xmap/Pl3xMapObserverHandler.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2024 Silverwolfg11
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package me.silverwolfg11.maptowny.platform.pl3xmap;
+
+import me.silverwolfg11.maptowny.platform.MapPlatformObserver;
+import net.pl3x.map.core.Pl3xMap;
+import net.pl3x.map.core.event.EventHandler;
+import net.pl3x.map.core.event.EventListener;
+import net.pl3x.map.core.event.server.Pl3xMapDisabledEvent;
+import net.pl3x.map.core.event.server.Pl3xMapEnabledEvent;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class Pl3xMapObserverHandler {
+    private final CopyOnWriteArrayList<MapPlatformObserver> observers = new CopyOnWriteArrayList<>();
+    private final List<MapPlatformObserver> unsetupObservers = new ArrayList<>();
+
+    private final AtomicBoolean pluginEnabled = new AtomicBoolean(true);
+
+    public Pl3xMapObserverHandler() {
+        Pl3xMap.api().getEventRegistry().register(new EventListener() {
+            @EventHandler
+            public void onPl3xMapEnabled(Pl3xMapEnabledEvent event) {
+                Pl3xMapObserverHandler.this.onPl3xMapEnabled();
+            }
+
+            @EventHandler
+            public void onPl3xMapDisabled(Pl3xMapDisabledEvent event) {
+                Pl3xMapObserverHandler.this.onPl3xMapDisabled();
+            }
+        });
+    }
+
+    public boolean registerObserver(MapPlatformObserver observer) {
+        if (observers.contains(observer)) {
+            return false;
+        }
+
+        synchronized (unsetupObservers) {
+            if (unsetupObservers.contains(observer)) {
+                return false;
+            }
+        }
+
+        setupObserver(observer);
+        return true;
+    }
+
+    public boolean unregisterObserver(MapPlatformObserver observer) {
+        if (observers.remove(observer)) {
+            return true;
+        }
+
+        synchronized (unsetupObservers) {
+            if (unsetupObservers.remove(observer)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public void disableObservers() {
+        pluginEnabled.set(false);
+        observers.clear();
+        synchronized (unsetupObservers) {
+            unsetupObservers.clear();
+        }
+    }
+
+    private void setupObserver(MapPlatformObserver observer) {
+        if (Pl3xMap.api().isEnabled()) {
+            observer.onObserverSetup();
+            observers.add(observer);
+        }
+        else {
+            synchronized (unsetupObservers) {
+                unsetupObservers.add(observer);
+            }
+        }
+    }
+
+    private void onPl3xMapEnabled() {
+        if (!pluginEnabled.get()) {
+            return;
+        }
+
+        for (MapPlatformObserver observer : observers) {
+            observer.onPlatformEnabled();
+        }
+
+        List<MapPlatformObserver> tmpObservers;
+        synchronized (unsetupObservers) {
+            tmpObservers = new ArrayList<>(unsetupObservers);
+            unsetupObservers.clear();
+        }
+
+        // Setup first-time observers
+        for (MapPlatformObserver observer : tmpObservers) {
+            observer.onObserverSetup();
+        }
+
+        observers.addAll(tmpObservers);
+
+    }
+
+    private void onPl3xMapDisabled() {
+        if (!pluginEnabled.get()) {
+            return;
+        }
+
+        for (MapPlatformObserver observer : observers) {
+            observer.onPlatformDisabled();
+        }
+    }
+}

--- a/maptowny-pl3xmap/src/main/java/me/silverwolfg11/maptowny/platform/pl3xmap/Pl3xMapPlatform.java
+++ b/maptowny-pl3xmap/src/main/java/me/silverwolfg11/maptowny/platform/pl3xmap/Pl3xMapPlatform.java
@@ -23,6 +23,7 @@
 package me.silverwolfg11.maptowny.platform.pl3xmap;
 
 import me.silverwolfg11.maptowny.platform.MapPlatform;
+import me.silverwolfg11.maptowny.platform.MapPlatformObserver;
 import me.silverwolfg11.maptowny.platform.MapWorld;
 import net.pl3x.map.core.Pl3xMap;
 import net.pl3x.map.core.image.IconImage;
@@ -33,6 +34,19 @@ import org.jetbrains.annotations.Nullable;
 import java.awt.image.BufferedImage;
 
 public class Pl3xMapPlatform implements MapPlatform {
+
+    private final Pl3xMapObserverHandler observerHandler = new Pl3xMapObserverHandler();
+
+    @Override
+    public boolean registerObserver(@NotNull MapPlatformObserver observer) {
+        return observerHandler.registerObserver(observer);
+    }
+
+    @Override
+    public boolean unregisterObserver(@NotNull MapPlatformObserver observer) {
+        return observerHandler.unregisterObserver(observer);
+    }
+
     @Override
     public @NotNull String getPlatformName() {
         return "Pl3xMap";
@@ -74,5 +88,10 @@ public class Pl3xMapPlatform implements MapPlatform {
     @Override
     public boolean unregisterIcon(@NotNull String iconKey) {
         return Pl3xMap.api().getIconRegistry().unregister(iconKey) != null;
+    }
+
+    @Override
+    public void shutdown() {
+        observerHandler.disableObservers();
     }
 }

--- a/maptowny-plugin/src/main/java/me/silverwolfg11/maptowny/MapTowny.java
+++ b/maptowny-plugin/src/main/java/me/silverwolfg11/maptowny/MapTowny.java
@@ -208,4 +208,8 @@ public final class MapTowny extends JavaPlugin implements MapTownyPlugin {
     public void async(Runnable run) {
         scheduler.scheduleAsyncTask(run);
     }
+
+    public MapTownyScheduler getScheduler() {
+        return scheduler;
+    }
 }

--- a/maptowny-squaremap/src/main/java/me/silverwolfg11/maptowny/platform/squaremap/SquareMapPlatform.java
+++ b/maptowny-squaremap/src/main/java/me/silverwolfg11/maptowny/platform/squaremap/SquareMapPlatform.java
@@ -23,6 +23,7 @@
 package me.silverwolfg11.maptowny.platform.squaremap;
 
 import me.silverwolfg11.maptowny.platform.MapPlatform;
+import me.silverwolfg11.maptowny.platform.MapPlatformObserver;
 import me.silverwolfg11.maptowny.platform.MapWorld;
 import org.bukkit.World;
 import org.jetbrains.annotations.NotNull;
@@ -33,11 +34,34 @@ import xyz.jpenilla.squaremap.api.SquaremapProvider;
 import xyz.jpenilla.squaremap.api.WorldIdentifier;
 
 import java.awt.image.BufferedImage;
+import java.util.ArrayList;
+import java.util.List;
 
 public class SquareMapPlatform implements MapPlatform {
+
+    private final List<MapPlatformObserver> platformObservers = new ArrayList<>();
+
     @Override
     public @NotNull String getPlatformName() {
         return "squaremap";
+    }
+
+    @Override
+    public boolean registerObserver(@NotNull MapPlatformObserver observer) {
+        if (platformObservers.contains(observer)) {
+            return false;
+        }
+
+        // SquareMap doesn't implement a way to monitor enable/disable.
+        observer.onObserverSetup();
+        platformObservers.add(observer);
+        return true;
+    }
+
+    @Override
+    public boolean unregisterObserver(@NotNull MapPlatformObserver observer) {
+        // Not keeping track of observers
+        return platformObservers.remove(observer);
     }
 
     @Override
@@ -77,5 +101,10 @@ public class SquareMapPlatform implements MapPlatform {
         boolean hasKey = SquaremapProvider.get().iconRegistry().hasEntry(key);
         SquaremapProvider.get().iconRegistry().unregister(key);
         return hasKey;
+    }
+
+    @Override
+    public void shutdown() {
+        platformObservers.clear();
     }
 }


### PR DESCRIPTION
The MapPlatformObservers API resolves the issue of MapTowny not being aware to platform-based events such as a map platform reloading. Most platforms do throw events for similar circumstances like when the platform is being reloaded (the exception being squaremap which doesn't indicate this at all).

Fixes #60